### PR TITLE
fix: undo breaking change in releases_created output

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -166,8 +166,8 @@ function setPathOutput(path: string, key: string, value: string | boolean) {
 function outputReleases(releases: (CreatedRelease | undefined)[]) {
   releases = releases.filter(release => release !== undefined);
   const pathsReleased = [];
-  core.setOutput('releases_created', releases.length > 0);
   if (releases.length) {
+    core.setOutput('releases_created', true);
     for (const release of releases) {
       if (!release) {
         continue;

--- a/test/release-please.ts
+++ b/test/release-please.ts
@@ -450,7 +450,7 @@ describe('release-please-action', () => {
       assert.strictEqual(Object.hasOwnProperty.call(output, 'pr'), false);
       assert.deepStrictEqual(output.paths_released, '[]');
       assert.deepStrictEqual(output.prs_created, false);
-      assert.deepStrictEqual(output.releases_created, false);
+      assert.deepStrictEqual(output.releases_created, undefined);
     });
   });
 });


### PR DESCRIPTION
## The issue this fixes

An undocumented breaking change slipped into the v4 release which causes the conditional in actions to stop working as documented. I encountered it when migrating some of my projects and an issue has already been opened (#912).

In v3 the following step would only run if releases were created. In v4 the action will always run:

```yml
- run: echo "releases happened"
  if: ${{ steps.release.outputs.releases_created }}
```

This is because the [`@actions/core`](https://github.com/actions/toolkit) npm package `core.setOutput` method always casts values to a string, so when we call the following:

```js
core.setOutput('releases_created', releases.length > 0);
```

The output of the action will always either be `"true"` or `"false"` as a string. This is a problem because our `if` statement above will always evaluate this to `true` and run the conditional step.

The only reason this worked in v3 is because the `core.setOutput` was called only if `releases.length` was greater than zero rather than being passed the condition.

  * [Relevant v3 code](https://github.com/google-github-actions/release-please-action/blob/db8f2c60ee802b3748b512940dde88eabd7b7e01/index.js#L223-L224)

  * [Equivalent v4 code](https://github.com/google-github-actions/release-please-action/blob/cc61a07e2da466bebbc19b3a7dd01d6aecb20d1e/src/index.ts#L165)

So in v3 the possible values for `releases_created` was actually `"true"` or `undefined`. This was never an issue because `"true"` is truthy and `undefined` is falsy so the conditions in our actions worked as expected.

## Approach

I've moved the `releases_created` output back inside the conditional to switch the behaviour to match `v3`.

## Alternatives

If you're not happy with this change then I think the documentation should be updated to highlight this gotcha and the changelog for v4 should include it.

## Potential additional work

`core.setOutput` casting to a string has been noted in issues [in the `@actions/core` repo before](https://github.com/actions/toolkit/issues/1368), but all the documentation on this action indicates that outputs are set to `true` or `false`. It might be worth changing this documentation to explain that the values are all strings rather than booleans.
