### PR TITLE
Fix: Add action outputs to action manifest

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -58,6 +58,33 @@ inputs:
     description: 'if set to true, then do not try to open pull requests'
     required: false
     default: false
+outputs:
+  releases_created: 
+    description: '`true` if a root component release was created, `false` otherwise'
+  release_created:
+    description: 'Directly related to [**Create a release**](https://developer.github.com/v3/repos/releases/#response-4) API'
+  paths_released:
+    description: 'A JSON string of the array of paths that had releases created (`[]` if )'
+  prs_created:
+    description: '`true` if any pull request was created or updated'
+  pr:
+    description: 'A JSON string of the [PullRequest object](https://github.com/googleapis/release-please/blob/main/src/pull-request.ts#L15) (unset if no release created)'
+  prs: 
+    description: 'A JSON string of the array of [PullRequest objects](https://github.com/googleapis/release-please/blob/main/src/pull-request.ts#L15) (unset if no release created)'
+  upload_url:
+    description: 'Directly related to [**Create a release**](https://developer.github.com/v3/repos/releases/#response-4) API'
+  html_url:
+    description: 'Directly related to [**Create a release**](https://developer.github.com/v3/repos/releases/#response-4) API'
+  tag_name:
+    description: 'Directly related to [**Create a release**](https://developer.github.com/v3/repos/releases/#response-4) API'
+  major:
+    description: 'Number representing major semver value'
+  minor:
+    description: 'Number representing minor semver value'
+  patch:
+    description: 'Number representing patch semver value'
+  sha:
+    description: 'SHA that a GitHub release was tagged at'
 runs:
   using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
<!--
Thank you for proposing a pull request! Please note that SOME TESTS WILL
LIKELY FAIL due to how GitHub exposes secrets in Pull Requests from forks.
Someone from the team will review your Pull Request and respond.

Please describe your change and any implementation details below.
-->
Outputs of a Github action should be defined within `action.yml` manifest as stated in documentation.
> "[The data in the metadata file defines the inputs, outputs, and runs configuration for your action](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#about-yaml-syntax-for-github-actions)."

I've skipped mapping of outputs with dynamic keys, "paths outputs". 