### PR TITLE
docs: fix small README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ you can see a mapping of the old option to the new option:
 | `changelog-path`                   | `$.packages[path].changelog-path`                                                     | Package-only option                                                                 |
 | `component`                        | `$.packages[path].component`                                                          | Package-only option                                                                 |
 | `package-name`                     | `$.packages[path].package-name`                                                       | Package-only option                                                                 |
-| `always-link-local`                | `$.always-link-loca`                                                                  | Root-only option                                                                    |
+| `always-link-local`                | `$.always-link-local`                                                                 | Root-only option                                                                    |
 | `bootstrap-sha`                    | `$.bootstrap-sha`                                                                     | Root-only option                                                                    |
 | `commit-search-depth`              | `$.commit-search-depth`                                                               | Root-only option                                                                    |
 | `group-pull-request-title-pattern` | `$.group-pull-request-title-pattern`                                                  | Root-only option                                                                    |


### PR DESCRIPTION
fix typo

searching the other codebase seems to confirm this is a typo (results show "local" not "loca")

https://github.com/search?q=repo%3Agoogleapis%2Frelease-please%20always-link-local&type=code

<!--
Thank you for proposing a pull request! Please note that SOME TESTS WILL
LIKELY FAIL due to how GitHub exposes secrets in Pull Requests from forks.
Someone from the team will review your Pull Request and respond.

Please describe your change and any implementation details below.
-->
