### PR TITLE
feat: add release id to output

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ If you have a root component (path is `.` or unset), then the action will also o
 | `upload_url`         | Directly related to [**Create a release**](https://developer.github.com/v3/repos/releases/#response-4) API |
 | `html_url`           | Directly related to [**Create a release**](https://developer.github.com/v3/repos/releases/#response-4) API |
 | `tag_name`           | Directly related to [**Create a release**](https://developer.github.com/v3/repos/releases/#response-4) API |
+| `id`                 | Directly related to [**Create a release**](https://developer.github.com/v3/repos/releases/#response-4) API |
 | `major`              | Number representing major semver value                                                                     |
 | `minor`              | Number representing minor semver value                                                                     |
 | `patch`              | Number representing patch semver value                                                                     |
@@ -195,6 +196,7 @@ This prefix allows you to distinguish values for different releases.
 | `<path>--upload_url`      | Directly related to [**Create a release**](https://developer.github.com/v3/repos/releases/#response-4) API |
 | `<path>--html_url`        | Directly related to [**Create a release**](https://developer.github.com/v3/repos/releases/#response-4) API |
 | `<path>--tag_name`        | Directly related to [**Create a release**](https://developer.github.com/v3/repos/releases/#response-4) API |
+| `<path>--id`              | Directly related to [**Create a release**](https://developer.github.com/v3/repos/releases/#response-4) API |
 | `<path>--major`           | Number representing major semver value                                                                     |
 | `<path>--minor`           | Number representing minor semver value                                                                     |
 | `<path>--patch`           | Number representing patch semver value                                                                     |

--- a/src/index.ts
+++ b/src/index.ts
@@ -187,6 +187,7 @@ function outputReleases(releases: (CreatedRelease | undefined)[]) {
         if (key === 'uploadUrl') key = 'upload_url';
         if (key === 'notes') key = 'body';
         if (key === 'url') key = 'html_url';
+        if (key === 'id') key = 'id';
         setPathOutput(path, key, value);
       }
     }


### PR DESCRIPTION
Some actions can upload assets to existing release by it's `id` like for example:
- https://github.com/tauri-apps/tauri-action?tab=readme-ov-file#release-configuration