### PR TITLE
chore: update release tagging step name

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -45,7 +45,7 @@ jobs:
           release-type: node
           skip-github-pull-request: true
       - uses: actions/checkout@v4
-      - name: tag major and patch versions
+      - name: tag major and minor versions
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com


### PR DESCRIPTION
There is a small issue in the step name for creating major/minor tags. Although it's not critical and doesn't impact any functionality, keeping a valid name in the step would be ideal.

Note: The documentation in `README.md` for creating major/minor tags is correct.