### PR TITLE
fix: pass inputs.path to manifest config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -110,7 +110,8 @@ function loadOrBuildManifest(
     github.repository.defaultBranch,
     inputs.configFile,
     inputs.manifestFile,
-    manifestOverrides
+    manifestOverrides,
+    inputs.path
   );
 }
 


### PR DESCRIPTION
Found a bit strange that `path` can be passed to manifest loaded from config but not from manifest.
It can be useful to have multiple release-please actions configured separately by individual paths