### PR TITLE
feat: add ability to output candidate releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ steps:
 | `changelog-host`           | The proto://host where commits live. Defaults to `${{ github.server_url }}` (usually `https://github.com`)                             |
 | `versioning-strategy`      | The versioning strategy to use. Defaults to `default`                                                                                  |
 | `release-as`               | The version to release as.                                                                                                             |
+| `dry-run`                  | If `true`, the action outputs pending releases and/or pending pull requests, but does not create them.                                 |
 
 ## GitHub Credentials
 
@@ -97,7 +98,7 @@ the `token` configuration option.
 If your repository is in an organization, you may need to
 [permit github actions to create an approve PRs](https://stackoverflow.com/questions/72376229).
 
-> [!WARNING]  
+> [!WARNING]
 > If using GitHub Actions, you will need to specify a `token` for your workflows to run on
 > Release Please's releases and PRs. See [the heading below](#other-actions-on-release-please-prs).
 
@@ -170,13 +171,16 @@ New types of releases can be [added here](https://github.com/googleapis/release-
 
 > Properties that are available after the action executed.
 
-| output             | description                                                                                                                                                       |
-| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `releases_created` | `true` if any release was created, `false` otherwise                                                                                                              |
-| `paths_released`   | A JSON string of the array of paths that had releases created (`[]` if nothing was released)                                                                                          |
-| `prs_created`      | `true` if any pull request was created or updated                                                                                                                 |
-| `pr`               | A JSON string of the [PullRequest object](https://github.com/googleapis/release-please/blob/main/src/pull-request.ts#L15) (unset if no release created)           |
-| `prs`              | A JSON string of the array of [PullRequest objects](https://github.com/googleapis/release-please/blob/main/src/pull-request.ts#L15) (unset if no release created) |
+| output             | description                                                                                                                                                                                                                                                                           |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `releases_created` | `true` if any release was created, `false` otherwise.                                                                                                                                                                                                                                 |
+| `paths_released`   | A JSON string of the array of paths that had releases created (`[]` if nothing was released).                                                                                                                                                                                         |
+| `releases_pending` | `true` if any candidate release is pending (when running in dry-run mode).                                                                                                                                                                                                            |
+| `paths_to_release` | A JSON string of the array of paths that have pending candidate releases (when running in dry-run mode).                                                                                                                                                                              |
+| `prs_created`      | `true` if any pull request was created or updated.                                                                                                                                                                                                                                    |
+| `prs_pending`      | `true` if any candidate pull request is pending (when running in dry-run mode).                                                                                                                                                                                                       |
+| `pr`               | A JSON string of the [PullRequest object](https://github.com/googleapis/release-please/blob/main/src/pull-request.ts#L15) (in dry-run [ReleasePullRequest objects](https://github.com/googleapis/release-please/blob/main/src/release-pull-request.ts#L20), unset otherwise)           |
+| `prs`              | A JSON string of the array of [PullRequest objects](https://github.com/googleapis/release-please/blob/main/src/pull-request.ts#L15) (in dry-run [ReleasePullRequest objects](https://github.com/googleapis/release-please/blob/main/src/release-pull-request.ts#L20), unset otherwise) |
 
 ### Root component outputs
 

--- a/action.yml
+++ b/action.yml
@@ -74,6 +74,10 @@ inputs:
     description: 'The version to release as.'
     required: false
     default: ''
+  dry-run:
+    description: 'if set to true, the action lists build releases and/or PRs but does not create them'
+    required: false
+    default: false
 runs:
   using: 'node24'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -105881,6 +105881,7 @@ function parseInputs() {
         changelogHost: core.getInput('changelog-host') || DEFAULT_GITHUB_SERVER_URL,
         versioningStrategy: getOptionalInput('versioning-strategy'),
         releaseAs: getOptionalInput('release-as'),
+        dryRun: getOptionalBooleanInput('dry-run'),
     };
     return inputs;
 }
@@ -105930,15 +105931,26 @@ async function main(fetchOverride) {
     core.info(`Running release-please version: ${release_please_1.VERSION}`);
     const inputs = parseInputs();
     const github = await getGitHubInstance(inputs, fetchOverride);
+    const manifest = await loadOrBuildManifest(github, inputs);
     if (!inputs.skipGitHubRelease) {
-        const manifest = await loadOrBuildManifest(github, inputs);
-        core.debug('Creating releases');
-        outputReleases(await manifest.createReleases());
+        if (inputs.dryRun) {
+            core.debug('Listing pending releases');
+            outputCandidateReleases(await manifest.buildReleases());
+        }
+        else {
+            core.debug('Creating releases');
+            outputReleases(await manifest.createReleases());
+        }
     }
     if (!inputs.skipGitHubPullRequest) {
-        const manifest = await loadOrBuildManifest(github, inputs);
-        core.debug('Creating pull requests');
-        outputPRs(await manifest.createPullRequests());
+        if (inputs.dryRun) {
+            core.debug('Listing pending pull requests');
+            outputCandidatePRs(await manifest.buildPullRequests());
+        }
+        else {
+            core.debug('Creating pull requests');
+            outputPRs(await manifest.createPullRequests());
+        }
     }
 }
 exports.main = main;
@@ -106008,9 +106020,45 @@ function outputReleases(releases) {
     // to matrix in next step:
     core.setOutput('paths_released', JSON.stringify(pathsReleased));
 }
+function outputCandidateReleases(releases) {
+    releases = releases.filter(release => release !== undefined);
+    const pathsReleased = [];
+    core.setOutput('releases_pending', releases.length > 0);
+    if (releases.length) {
+        for (const release of releases) {
+            if (!release) {
+                continue;
+            }
+            const path = release.path || '.';
+            if (path) {
+                pathsReleased.push(path);
+                // If the special root release is set (representing project root)
+                // and this is explicitly a manifest release, set the release_created boolean.
+                setPathOutput(path, 'release_pending', true);
+            }
+            if (release.tag) {
+                // Historically tagName was output as tag_name, keep this
+                // consistent to avoid breaking change:
+                setPathOutput(path, 'tag_name', release.tag.toString());
+                setPathOutput(path, 'body', release.notes);
+            }
+        }
+    }
+    // Paths of all releases that were created, so that they can be passed
+    // to matrix in next step:
+    core.setOutput('paths_to_release', JSON.stringify(pathsReleased));
+}
 function outputPRs(prs) {
     prs = prs.filter(pr => pr !== undefined);
     core.setOutput('prs_created', prs.length > 0);
+    if (prs.length) {
+        core.setOutput('pr', prs[0]);
+        core.setOutput('prs', JSON.stringify(prs));
+    }
+}
+function outputCandidatePRs(prs) {
+    prs = prs.filter(pr => pr !== undefined);
+    core.setOutput('prs_pending', prs.length > 0);
     if (prs.length) {
         core.setOutput('pr', prs[0]);
         core.setOutput('prs', JSON.stringify(prs));

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import * as core from '@actions/core';
-import {GitHub, Manifest, CreatedRelease, PullRequest, VERSION} from 'release-please';
+import {GitHub, Manifest, CreatedRelease, PullRequest, VERSION, CandidateRelease, ReleasePullRequest} from 'release-please';
 
 const DEFAULT_CONFIG_FILE = 'release-please-config.json';
 const DEFAULT_MANIFEST_FILE = '.release-please-manifest.json';
@@ -45,6 +45,7 @@ interface ActionInputs {
   changelogHost: string;
   versioningStrategy?: string;
   releaseAs?: string;
+  dryRun?: boolean;
 }
 
 function parseInputs(): ActionInputs {
@@ -69,6 +70,7 @@ function parseInputs(): ActionInputs {
     changelogHost: core.getInput('changelog-host') || DEFAULT_GITHUB_SERVER_URL,
     versioningStrategy: getOptionalInput('versioning-strategy'),
     releaseAs: getOptionalInput('release-as'),
+    dryRun: getOptionalBooleanInput('dry-run'),
   };
   return inputs;
 }
@@ -137,17 +139,26 @@ export async function main(fetchOverride?: any) {
   core.info(`Running release-please version: ${VERSION}`)
   const inputs = parseInputs();
   const github = await getGitHubInstance(inputs, fetchOverride);
+  const manifest = await loadOrBuildManifest(github, inputs);
 
   if (!inputs.skipGitHubRelease) {
-    const manifest = await loadOrBuildManifest(github, inputs);
-    core.debug('Creating releases');
-    outputReleases(await manifest.createReleases());
+    if (inputs.dryRun) {
+      core.debug('Listing pending releases');
+      outputCandidateReleases(await manifest.buildReleases());
+    } else {
+      core.debug('Creating releases');
+      outputReleases(await manifest.createReleases());
+    }
   }
 
   if (!inputs.skipGitHubPullRequest) {
-    const manifest = await loadOrBuildManifest(github, inputs);
-    core.debug('Creating pull requests');
-    outputPRs(await manifest.createPullRequests());
+    if (inputs.dryRun) {
+      core.debug('Listing pending pull requests');
+      outputCandidatePRs(await manifest.buildPullRequests());
+    } else {
+      core.debug('Creating pull requests');
+      outputPRs(await manifest.createPullRequests());
+    }
   }
 }
 
@@ -216,9 +227,47 @@ function outputReleases(releases: (CreatedRelease | undefined)[]) {
   core.setOutput('paths_released', JSON.stringify(pathsReleased));
 }
 
+function outputCandidateReleases(releases: CandidateRelease[]) {
+  releases = releases.filter(release => release !== undefined);
+  const pathsReleased = [];
+  core.setOutput('releases_pending', releases.length > 0);
+  if (releases.length) {
+    for (const release of releases) {
+      if (!release) {
+        continue;
+      }
+      const path = release.path || '.';
+      if (path) {
+        pathsReleased.push(path);
+        // If the special root release is set (representing project root)
+        // and this is explicitly a manifest release, set the release_created boolean.
+        setPathOutput(path, 'release_pending', true);
+      }
+      if (release.tag) {
+        // Historically tagName was output as tag_name, keep this
+        // consistent to avoid breaking change:
+        setPathOutput(path, 'tag_name', release.tag.toString());
+        setPathOutput(path, 'body', release.notes)
+      }
+    }
+  }
+  // Paths of all releases that were created, so that they can be passed
+  // to matrix in next step:
+  core.setOutput('paths_to_release', JSON.stringify(pathsReleased));
+}
+
 function outputPRs(prs: (PullRequest | undefined)[]) {
   prs = prs.filter(pr => pr !== undefined);
   core.setOutput('prs_created', prs.length > 0);
+  if (prs.length) {
+    core.setOutput('pr', prs[0]);
+    core.setOutput('prs', JSON.stringify(prs));
+  }
+}
+
+function outputCandidatePRs(prs: ReleasePullRequest[]) {
+  prs = prs.filter(pr => pr !== undefined);
+  core.setOutput('prs_pending', prs.length > 0);
   if (prs.length) {
     core.setOutput('pr', prs[0]);
     core.setOutput('prs', JSON.stringify(prs));


### PR DESCRIPTION
For the purposes of releasing, it is useful to just get the information of the packages that are about to be released.
If `only: 'list-candidate-releases'` is set, only output information about which packages would be released. 

It provides `releases_pending` and `paths_to_release` as the outputs.

In order to enable this new feature, I've added a new input called `only` that allows running only the desired functionality (`'create-github-releases' | 'list-candidate-releases' | 'update-pull-requests'`). 
It is not a breaking change, and is backwards compatible with the `skipGitHubRelease` and `skipGitHubPullRequest` inputs.