### PR TITLE
feat: support for skip-labeling parameter for GitHub action

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ steps:
 | `proxy-server`             | Configure a proxy servier in the form of `<host>:<port>` e.g. `proxy-host.com:8080`                                                    |
 | `skip-github-release`      | If `true`, do not attempt to create releases. This is useful if splitting release tagging from PR creation.                            |
 | `skip-github-pull-request` | If `true`, do not attempt to create release pull requests. This is useful if splitting release tagging from PR creation.               |
+| `skip-labeling`            | If `true`, do not attempt to label the PR.                                                                                          |
 
 ## GitHub Credentials
 

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'huksley-release-please-action'
+name: 'release-please-action'
 description: 'automated releases based on conventional commits'
 author: Google LLC
 inputs:

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'release-please-action'
+name: 'huksley-release-please-action'
 description: 'automated releases based on conventional commits'
 author: Google LLC
 inputs:
@@ -56,6 +56,10 @@ inputs:
     default: false
   skip-github-pull-request:
     description: 'if set to true, then do not try to open pull requests'
+    required: false
+    default: false
+  skip-labeling:
+    description: 'if set to true, then do not try to label the PR'
     required: false
     default: false
   changelog-host:

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,6 @@ function parseInputs(): ActionInputs {
     includeComponentInTag: getOptionalBooleanInput('include-component-in-tag'),
     changelogHost: core.getInput('changelog-host') || DEFAULT_GITHUB_SERVER_URL,
   };
-  console.log("Running here", inputs.skipLabeling);
   return inputs;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ interface ActionInputs {
   targetBranch?: string;
   skipGitHubRelease?: boolean;
   skipGitHubPullRequest?: boolean;
+  skipLabeling?: boolean;
   fork?: boolean;
   includeComponentInTag?: boolean;
   changelogHost: string;
@@ -60,6 +61,7 @@ function parseInputs(): ActionInputs {
     proxyServer: getOptionalInput('proxy-server'),
     skipGitHubRelease: getOptionalBooleanInput('skip-github-release'),
     skipGitHubPullRequest: getOptionalBooleanInput('skip-github-pull-request'),
+    skipLabeling: getOptionalBooleanInput('skip-labeling'),
     fork: getOptionalBooleanInput('fork'),
     includeComponentInTag: getOptionalBooleanInput('include-component-in-tag'),
     changelogHost: core.getInput('changelog-host') || DEFAULT_GITHUB_SERVER_URL,
@@ -95,6 +97,7 @@ function loadOrBuildManifest(
       },
       {
         fork: inputs.fork,
+        skipLabeling: inputs.skipLabeling,
       },
       inputs.path
     );
@@ -102,6 +105,7 @@ function loadOrBuildManifest(
   const manifestOverrides = inputs.fork
     ? {
         fork: inputs.fork,
+        skipLabeling: inputs.skipLabeling,
       }
     : {};
   core.debug('Loading manifest from config file');

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,7 @@ function parseInputs(): ActionInputs {
     includeComponentInTag: getOptionalBooleanInput('include-component-in-tag'),
     changelogHost: core.getInput('changelog-host') || DEFAULT_GITHUB_SERVER_URL,
   };
+  console.log("Running here", inputs.skipLabeling);
   return inputs;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,7 +103,7 @@ function loadOrBuildManifest(
       inputs.path
     );
   }
-  const manifestOverrides = inputs.fork
+  const manifestOverrides = inputs.fork || inputs.skipLabeling
     ? {
         fork: inputs.fork,
         skipLabeling: inputs.skipLabeling,


### PR DESCRIPTION
Adds support and documentation for the skipLabeling option when running release-please from GitHub Actions.

This option in the config are ignored when running in release-please-action, and only honored when you pass it as an option via a command line. This PR adds the same support to GitHub action.

