### PR TITLE
docs: adds missing github action permissions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Automate releases with Conventional Commit Messages.
 
    permissions:
      contents: write
+     issues: write
      pull-requests: write
 
    name: release-please
@@ -119,6 +120,7 @@ This workflow will need the following permissions in your workflow file:
 ```yml
 permissions:
   contents: write
+  issues: write
   pull-requests: write
 ```
 


### PR DESCRIPTION
without the `issues: true` permission, users receive the following error:
![image](https://github.com/user-attachments/assets/be2b1c74-1479-462f-8b89-5e292a63ed2f)

Close #1105 