### PR TITLE
feat: add ability to select versioning-strategy and release-as

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -66,6 +66,14 @@ inputs:
     description: 'The proto://host where commits live. Default `https://github.com`'
     required: false
     default: ${{ github.server_url }}
+  versioning-strategy:
+    description: 'The versioning strategy to use.'
+    required: false
+    default: 'default'
+  release-as:
+    description: 'The version to release as.'
+    required: false
+    default: ''
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,8 @@ interface ActionInputs {
   fork?: boolean;
   includeComponentInTag?: boolean;
   changelogHost: string;
+  versioningStrategy?: string;
+  releaseAs?: string;
 }
 
 function parseInputs(): ActionInputs {
@@ -65,6 +67,8 @@ function parseInputs(): ActionInputs {
     fork: getOptionalBooleanInput('fork'),
     includeComponentInTag: getOptionalBooleanInput('include-component-in-tag'),
     changelogHost: core.getInput('changelog-host') || DEFAULT_GITHUB_SERVER_URL,
+    versioningStrategy: getOptionalInput('versioning-strategy'),
+    releaseAs: getOptionalInput('release-as'),
   };
   return inputs;
 }
@@ -94,6 +98,8 @@ function loadOrBuildManifest(
         releaseType: inputs.releaseType,
         includeComponentInTag: inputs.includeComponentInTag,
         changelogHost: inputs.changelogHost,
+        versioning: inputs.versioningStrategy,
+        releaseAs: inputs.releaseAs,
       },
       {
         fork: inputs.fork,

--- a/test/release-please.ts
+++ b/test/release-please.ts
@@ -178,7 +178,7 @@ describe('release-please-action', () => {
         });
         fakeManifest.createReleases.resolves([]);
         fakeManifest.createPullRequests.resolves([]);
-        await action.main();
+        await action.main(fetch);
         sinon.assert.calledOnce(fakeManifest.createReleases);
         sinon.assert.calledOnce(fakeManifest.createPullRequests);
 
@@ -202,7 +202,7 @@ describe('release-please-action', () => {
         });
         fakeManifest.createReleases.resolves([]);
         fakeManifest.createPullRequests.resolves([]);
-        await action.main();
+        await action.main(fetch);
         sinon.assert.calledOnce(fakeManifest.createReleases);
         sinon.assert.calledOnce(fakeManifest.createPullRequests);
 

--- a/test/release-please.ts
+++ b/test/release-please.ts
@@ -171,6 +171,53 @@ describe('release-please-action', () => {
           sinon.match.any,
         );
       });
+      it('allows specifying versioning-strategy', async () => {
+        restoreEnv = mockInputs({
+          'release-type': 'simple',
+          'versioning-strategy': 'default',
+        });
+        fakeManifest.createReleases.resolves([]);
+        fakeManifest.createPullRequests.resolves([]);
+        await action.main();
+        sinon.assert.calledOnce(fakeManifest.createReleases);
+        sinon.assert.calledOnce(fakeManifest.createPullRequests);
+
+        sinon.assert.calledWith(
+          fromConfigStub,
+          sinon.match.any,
+          sinon.match.string,
+          sinon.match({
+            releaseType: 'simple',
+            versioning: 'default',
+          }),
+          sinon.match.object,
+          sinon.match.any,
+        );
+      });
+
+      it('allows specifying release-as', async () => {
+        restoreEnv = mockInputs({
+          'release-type': 'simple',
+          'release-as': '2.0.0',
+        });
+        fakeManifest.createReleases.resolves([]);
+        fakeManifest.createPullRequests.resolves([]);
+        await action.main();
+        sinon.assert.calledOnce(fakeManifest.createReleases);
+        sinon.assert.calledOnce(fakeManifest.createPullRequests);
+
+        sinon.assert.calledWith(
+          fromConfigStub,
+          sinon.match.any,
+          sinon.match.string,
+          sinon.match({
+            releaseType: 'simple',
+            releaseAs: '2.0.0',
+          }),
+          sinon.match.object,
+          sinon.match.any,
+        );
+      });
     });
 
     describe('with manifest', () => {


### PR DESCRIPTION
Summary
This PR adds support for two new inputs to the release-please GitHub Action:

`versioning-strategy` Allows users to specify the versioning strategy to use for releases (e.g., default, always-bump-minor, etc.).
`release-as`: Allows users to specify the exact version to release as (e.g., 2.0.0).

Usage Example
```
- uses: googleapis/release-please-action@v4
  with:
    token: ${{ secrets.GITHUB_TOKEN }}
    release-type: node
    versioning-strategy: always-bump-minor
    release-as: 2.0.0
```
Motivation
These options provide more flexibility and control over how versions are determined and released, addressing use cases where the default behavior is not sufficient.