### PR TITLE
feat: add include-commit-authors input to include author info in changelogs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -74,6 +74,10 @@ inputs:
     description: 'The version to release as.'
     required: false
     default: ''
+  include-commit-authors:
+    description: 'If true, include commit authors in changelog entries (e.g., @username or author name).'
+    required: false
+    default: false
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ interface ActionInputs {
   changelogHost: string;
   versioningStrategy?: string;
   releaseAs?: string;
+  includeCommitAuthors?: boolean;
 }
 
 function parseInputs(): ActionInputs {
@@ -69,6 +70,7 @@ function parseInputs(): ActionInputs {
     changelogHost: core.getInput('changelog-host') || DEFAULT_GITHUB_SERVER_URL,
     versioningStrategy: getOptionalInput('versioning-strategy'),
     releaseAs: getOptionalInput('release-as'),
+    includeCommitAuthors: getOptionalBooleanInput('include-commit-authors'),
   };
   return inputs;
 }
@@ -100,7 +102,8 @@ function loadOrBuildManifest(
         changelogHost: inputs.changelogHost,
         versioning: inputs.versioningStrategy,
         releaseAs: inputs.releaseAs,
-      },
+        includeCommitAuthors: inputs.includeCommitAuthors,
+      } as any,
       {
         fork: inputs.fork,
         skipLabeling: inputs.skipLabeling,
@@ -127,6 +130,13 @@ function loadOrBuildManifest(
       core.debug(`Overriding changelogHost to: ${inputs.changelogHost}`);
       for (const path in manifest.repositoryConfig) {
         manifest.repositoryConfig[path].changelogHost = inputs.changelogHost;
+      }
+    }
+    // Override includeCommitAuthors for all paths if provided as action input
+    if (inputs.includeCommitAuthors !== undefined) {
+      core.debug(`Overriding includeCommitAuthors to: ${inputs.includeCommitAuthors}`);
+      for (const path in manifest.repositoryConfig) {
+        (manifest.repositoryConfig[path] as any).includeCommitAuthors = inputs.includeCommitAuthors;
       }
     }
     return manifest;

--- a/test/release-please.ts
+++ b/test/release-please.ts
@@ -218,6 +218,30 @@ describe('release-please-action', () => {
           sinon.match.any,
         );
       });
+
+      it('allows specifying include-commit-authors', async () => {
+        restoreEnv = mockInputs({
+          'release-type': 'simple',
+          'include-commit-authors': 'true',
+        });
+        fakeManifest.createReleases.resolves([]);
+        fakeManifest.createPullRequests.resolves([]);
+        await action.main(fetch);
+        sinon.assert.calledOnce(fakeManifest.createReleases);
+        sinon.assert.calledOnce(fakeManifest.createPullRequests);
+
+        sinon.assert.calledWith(
+          fromConfigStub,
+          sinon.match.any,
+          sinon.match.string,
+          sinon.match({
+            releaseType: 'simple',
+            includeCommitAuthors: true,
+          }),
+          sinon.match.object,
+          sinon.match.any,
+        );
+      });
     });
 
     describe('with manifest', () => {
@@ -363,6 +387,56 @@ describe('release-please-action', () => {
         // Verify that changelogHost was NOT added when using default value
         assert.strictEqual(fakeManifest.repositoryConfig['.'].changelogHost, undefined);
         assert.strictEqual(fakeManifest.repositoryConfig['packages/foo'].changelogHost, undefined);
+      });
+      it('modifies repositoryConfig with include-commit-authors', async () => {
+        restoreEnv = mockInputs({
+          'include-commit-authors': 'true',
+        });
+
+        // Create a mock repositoryConfig on the existing fakeManifest
+        const mockRepositoryConfig = {
+          '.': { releaseType: 'node' },
+          'packages/foo': { releaseType: 'node' }
+        };
+        // Use Object.defineProperty to set the readonly property
+        Object.defineProperty(fakeManifest, 'repositoryConfig', {
+          value: mockRepositoryConfig,
+          writable: true,
+          configurable: true
+        });
+        fakeManifest.createReleases.resolves([]);
+        fakeManifest.createPullRequests.resolves([]);
+
+        await action.main(fetch);
+
+        // Verify that includeCommitAuthors was added to all paths in repositoryConfig
+        assert.strictEqual((fakeManifest.repositoryConfig['.'] as any).includeCommitAuthors, true);
+        assert.strictEqual((fakeManifest.repositoryConfig['packages/foo'] as any).includeCommitAuthors, true);
+      });
+      it('modifies repositoryConfig with include-commit-authors set to false', async () => {
+        restoreEnv = mockInputs({
+          'include-commit-authors': 'false',
+        });
+
+        // Create a mock repositoryConfig on the existing fakeManifest
+        const mockRepositoryConfig = {
+          '.': { releaseType: 'node', includeCommitAuthors: true },
+          'packages/foo': { releaseType: 'node', includeCommitAuthors: true }
+        };
+        // Use Object.defineProperty to set the readonly property
+        Object.defineProperty(fakeManifest, 'repositoryConfig', {
+          value: mockRepositoryConfig,
+          writable: true,
+          configurable: true
+        });
+        fakeManifest.createReleases.resolves([]);
+        fakeManifest.createPullRequests.resolves([]);
+
+        await action.main(fetch);
+
+        // Verify that includeCommitAuthors was set to false for all paths
+        assert.strictEqual((fakeManifest.repositoryConfig['.'] as any).includeCommitAuthors, false);
+        assert.strictEqual((fakeManifest.repositoryConfig['packages/foo'] as any).includeCommitAuthors, false);
       });
     });
 


### PR DESCRIPTION
Adds a new action input `include-commit-authors` that appends commit author information to changelog entries.

**Example output:**
```
feat(vehicle)!: the_commit_message (#123) (@username)
```

## Depends on

This PR depends on https://github.com/googleapis/release-please/pull/2628. The `as any` type assertions here will be cleaned up once that's merged and a new release-please version is published.

## Changes

- Added `include-commit-authors` input to `action.yml`
- Updated `src/index.ts` to pass the option through to `Manifest.fromConfig()`
- Added override for manifest-based configs (similar to `changelogHost`)

## Usage

```yaml
- uses: google-github-actions/release-please-action@v4
  with:
    include-commit-authors: true
```

Or in `release-please-config.json`:
```json
{
  "include-commit-authors": true
}
```

## Tests

- Added tests for release-type config
- Added tests for manifest config override
- All existing tests pass

---

Thanks for your work on this project! Fixes #1063. Let me know if you'd like any changes.