### PR TITLE
feat: allow custom changelog sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,30 @@ steps:
       manifest-file: .release-please-manifest.json
 ```
 
+### Customizing Changelog Sections
+
+You can customize the changelog sections from the workflow level, which is useful for
+reusable workflows that need to enforce consistent changelog formatting across multiple
+repositories:
+
+```yaml
+steps:
+  - uses: googleapis/release-please-action@v4
+    with:
+      token: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
+      config-file: release-please-config.json
+      manifest-file: .release-please-manifest.json
+      # optional. override changelog sections for all packages
+      changelog-sections: |
+        [
+          {"type":"feat","section":"🚀 Features","hidden":false},
+          {"type":"fix","section":"🐞 Bug Fixes","hidden":false},
+          {"type":"perf","section":"✨ Performance","hidden":false},
+          {"type":"docs","section":"📚 Documentation","hidden":false},
+          {"type":"chore","section":"🧰 Maintenance","hidden":true}
+        ]
+```
+
 ## Action Inputs
 
 | input                      | description                                                                                                                            |
@@ -85,6 +109,7 @@ steps:
 | `skip-github-release`      | If `true`, do not attempt to create releases. This is useful if splitting release tagging from PR creation.                            |
 | `skip-github-pull-request` | If `true`, do not attempt to create release pull requests. This is useful if splitting release tagging from PR creation.               |
 | `skip-labeling`            | If `true`, do not attempt to label the PR.                                                                                          |
+| `changelog-sections`       | JSON array defining changelog sections. Example: `[{"type":"feat","section":"Features","hidden":false}]`. Overrides config file settings for all packages. |
 
 ## GitHub Credentials
 

--- a/action.yml
+++ b/action.yml
@@ -74,6 +74,10 @@ inputs:
     description: 'The version to release as.'
     required: false
     default: ''
+  changelog-sections:
+    description: 'JSON formatted changelog sections configuration. Example: [{"type":"feat","section":"Features","hidden":false}]'
+    required: false
+    default: ''
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/test/release-please.ts
+++ b/test/release-please.ts
@@ -12,17 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {describe, it, beforeEach, afterEach} from 'mocha';
+import { describe, it, beforeEach, afterEach } from 'mocha';
 import * as action from '../src/index';
 import * as assert from 'assert';
 import * as core from '@actions/core';
 import * as sinon from 'sinon';
 import * as nock from 'nock';
-import {RestoreFn} from 'mocked-env';
+import { RestoreFn } from 'mocked-env';
 import mockedEnv from 'mocked-env';
 const fetch = require('node-fetch');
 
-import {Manifest, GitHub} from 'release-please';
+import { Manifest, GitHub } from 'release-please';
 // As defined in action.yml
 
 const DEFAULT_INPUTS: Record<string, string> = {
@@ -55,7 +55,7 @@ process.env.GITHUB_REPOSITORY = 'fakeOwner/fakeRepo';
 
 function mockInputs(inputs: Record<string, string>): RestoreFn {
   const envVars: Record<string, string> = {};
-  for (const [name, val] of Object.entries({...DEFAULT_INPUTS, ...inputs})) {
+  for (const [name, val] of Object.entries({ ...DEFAULT_INPUTS, ...inputs })) {
     envVars[`INPUT_${name.replace(/ /g, '_').toUpperCase()}`] = val;
   }
   return mockedEnv(envVars);
@@ -81,7 +81,7 @@ describe('release-please-action', () => {
       'setOutput',
       (key: string, value: string | boolean) => {
         output[key] = value;
-      }
+      },
     );
     // Default branch lookup:
     nock('https://api.github.com').get('/repos/fakeOwner/fakeRepo').reply(200, {
@@ -153,7 +153,7 @@ describe('release-please-action', () => {
       });
       it('allows specifying fork', async () => {
         restoreEnv = mockInputs({
-          'fork': 'true',
+          fork: 'true',
           'release-type': 'simple',
         });
         fakeManifest.createReleases.resolves([]);
@@ -167,7 +167,7 @@ describe('release-please-action', () => {
           sinon.match.any,
           sinon.match.string,
           sinon.match.object,
-          sinon.match({fork: true}),
+          sinon.match({ fork: true }),
           sinon.match.any,
         );
       });
@@ -213,6 +213,34 @@ describe('release-please-action', () => {
           sinon.match({
             releaseType: 'simple',
             releaseAs: '2.0.0',
+          }),
+          sinon.match.object,
+          sinon.match.any,
+        );
+      });
+
+      it("allows specifying changelog-sections with release-type", async () => {
+        const changelogSections = [
+          { type: "feat", section: "Features", hidden: false },
+          { type: "fix", section: "Bug Fixes", hidden: false },
+        ];
+        restoreEnv = mockInputs({
+          "release-type": "simple",
+          "changelog-sections": JSON.stringify(changelogSections),
+        });
+        fakeManifest.createReleases.resolves([]);
+        fakeManifest.createPullRequests.resolves([]);
+        await action.main(fetch);
+        sinon.assert.calledOnce(fakeManifest.createReleases);
+        sinon.assert.calledOnce(fakeManifest.createPullRequests);
+
+        sinon.assert.calledWith(
+          fromConfigStub,
+          sinon.match.any,
+          sinon.match.string,
+          sinon.match({
+            releaseType: "simple",
+            changelogSections: changelogSections,
           }),
           sinon.match.object,
           sinon.match.any,
@@ -269,12 +297,12 @@ describe('release-please-action', () => {
           sinon.match.any,
           'dev',
           sinon.match.string,
-          sinon.match.string
+          sinon.match.string,
         );
       });
       it('allows specifying fork', async () => {
         restoreEnv = mockInputs({
-          'fork': 'true',
+          fork: 'true',
         });
         fakeManifest.createReleases.resolves([]);
         fakeManifest.createPullRequests.resolves([]);
@@ -288,7 +316,7 @@ describe('release-please-action', () => {
           sinon.match.string,
           sinon.match.string,
           sinon.match.string,
-          sinon.match({fork: true}),
+          sinon.match({ fork: true }),
         );
       });
       it('allows specifying changelog-host', async () => {
@@ -311,7 +339,7 @@ describe('release-please-action', () => {
           sinon.match.string,
           sinon.match.string,
           sinon.match.string,
-          sinon.match(arg => !arg.hasOwnProperty('changelogHost')),
+          sinon.match((arg) => !arg.hasOwnProperty('changelogHost')),
         );
       });
       it('modifies repositoryConfig with custom changelog-host', async () => {
@@ -322,13 +350,13 @@ describe('release-please-action', () => {
         // Create a mock repositoryConfig on the existing fakeManifest
         const mockRepositoryConfig = {
           '.': { releaseType: 'node' },
-          'packages/foo': { releaseType: 'node' }
+          'packages/foo': { releaseType: 'node' },
         };
         // Use Object.defineProperty to set the readonly property
         Object.defineProperty(fakeManifest, 'repositoryConfig', {
           value: mockRepositoryConfig,
           writable: true,
-          configurable: true
+          configurable: true,
         });
         fakeManifest.createReleases.resolves([]);
         fakeManifest.createPullRequests.resolves([]);
@@ -336,8 +364,14 @@ describe('release-please-action', () => {
         await action.main(fetch);
 
         // Verify that changelogHost was added to all paths in repositoryConfig
-        assert.strictEqual(fakeManifest.repositoryConfig['.'].changelogHost, 'https://ghe.example.com');
-        assert.strictEqual(fakeManifest.repositoryConfig['packages/foo'].changelogHost, 'https://ghe.example.com');
+        assert.strictEqual(
+          fakeManifest.repositoryConfig['.'].changelogHost,
+          'https://ghe.example.com',
+        );
+        assert.strictEqual(
+          fakeManifest.repositoryConfig['packages/foo'].changelogHost,
+          'https://ghe.example.com',
+        );
       });
       it('does not modify repositoryConfig when changelog-host is default', async () => {
         restoreEnv = mockInputs({
@@ -347,13 +381,13 @@ describe('release-please-action', () => {
         // Create a mock repositoryConfig on the existing fakeManifest
         const mockRepositoryConfig = {
           '.': { releaseType: 'node' },
-          'packages/foo': { releaseType: 'node' }
+          'packages/foo': { releaseType: 'node' },
         };
         // Use Object.defineProperty to set the readonly property
         Object.defineProperty(fakeManifest, 'repositoryConfig', {
           value: mockRepositoryConfig,
           writable: true,
-          configurable: true
+          configurable: true,
         });
         fakeManifest.createReleases.resolves([]);
         fakeManifest.createPullRequests.resolves([]);
@@ -361,8 +395,49 @@ describe('release-please-action', () => {
         await action.main(fetch);
 
         // Verify that changelogHost was NOT added when using default value
-        assert.strictEqual(fakeManifest.repositoryConfig['.'].changelogHost, undefined);
-        assert.strictEqual(fakeManifest.repositoryConfig['packages/foo'].changelogHost, undefined);
+        assert.strictEqual(
+          fakeManifest.repositoryConfig['.'].changelogHost,
+          undefined,
+        );
+        assert.strictEqual(
+          fakeManifest.repositoryConfig['packages/foo'].changelogHost,
+          undefined,
+        );
+      });
+      it("allows specifying changelog-sections", async () => {
+        const changelogSections = [
+          { type: "feat", section: "Features", hidden: false },
+          { type: "fix", section: "Bug Fixes", hidden: false },
+        ];
+        restoreEnv = mockInputs({
+          "changelog-sections": JSON.stringify(changelogSections),
+        });
+
+        // Create a mock repositoryConfig on the existing fakeManifest
+        const mockRepositoryConfig = {
+          ".": { releaseType: "node" },
+          "packages/foo": { releaseType: "node" },
+        };
+        // Use Object.defineProperty to set the readonly property
+        Object.defineProperty(fakeManifest, "repositoryConfig", {
+          value: mockRepositoryConfig,
+          writable: true,
+          configurable: true,
+        });
+        fakeManifest.createReleases.resolves([]);
+        fakeManifest.createPullRequests.resolves([]);
+
+        await action.main(fetch);
+
+        // Verify that changelogSections was added to all paths in repositoryConfig
+        assert.deepStrictEqual(
+          fakeManifest.repositoryConfig["."].changelogSections,
+          changelogSections,
+        );
+        assert.deepStrictEqual(
+          fakeManifest.repositoryConfig["packages/foo"].changelogSections,
+          changelogSections,
+        );
       });
     });
 
@@ -386,7 +461,7 @@ describe('release-please-action', () => {
         sinon.match.any,
         sinon.match.string,
         'path/to/config.json',
-        'path/to/manifest.json'
+        'path/to/manifest.json',
       );
     });
 
@@ -416,7 +491,7 @@ describe('release-please-action', () => {
             port: 9000,
           },
           defaultBranch: 'dev',
-        })
+        }),
       );
     });
   });
@@ -474,7 +549,7 @@ describe('release-please-action', () => {
       sinon.assert.calledOnce(fakeManifest.createReleases);
       sinon.assert.calledOnce(fakeManifest.createPullRequests);
 
-      const {pr, prs, prs_created} = output;
+      const { pr, prs, prs_created } = output;
       assert.strictEqual(prs_created, true);
       assert.deepStrictEqual(pr, fixturePrs[0]);
       assert.deepStrictEqual(prs, JSON.stringify([fixturePrs[0]]));
@@ -560,7 +635,7 @@ describe('release-please-action', () => {
       sinon.assert.calledOnce(fakeManifest.createReleases);
       sinon.assert.calledOnce(fakeManifest.createPullRequests);
 
-      const {pr, prs} = output;
+      const { pr, prs } = output;
       assert.deepStrictEqual(pr, fixturePrs[0]);
       assert.deepStrictEqual(prs, JSON.stringify(fixturePrs));
     });


### PR DESCRIPTION
This pull request adds support for customizing changelog sections at the workflow level in the `release-please-action`, allowing users to override changelog formatting for all packages directly from the workflow file. It introduces a new `changelog-sections` input, updates documentation and action metadata, and ensures that these overrides are applied consistently. The changes are covered by new and updated tests.

**Changelog customization support:**

* Added a new optional `changelog-sections` input to the action (`action.yml`, `README.md`). This input allows users to specify a JSON array of changelog section configurations, overriding settings from the config file for all packages. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R77-R80) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R69-R92) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R112)
* Updated the documentation to explain how to use the new `changelog-sections` input, including examples and descriptions in the input table. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R69-R92) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R112)

**Implementation in action logic:**

* Parsed the `changelog-sections` input and passed it through the action's logic, ensuring it is applied to all repository configs in the manifest, both when building from config and when loading an existing manifest. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L16-R23) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R55) [[3]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R80-R82) [[4]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R99-R120) [[5]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R133-R143) [[6]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L123-R182)

**Testing improvements:**

* Added and updated tests to verify that `changelog-sections` can be specified, is parsed correctly, and is applied to all repository configs, both with and without a release type. [[1]](diffhunk://#diff-25842b7fdd198b8772289b4e61167ee3cf22b426aa817fdc1d5766def867ab74R221-R248) [[2]](diffhunk://#diff-25842b7fdd198b8772289b4e61167ee3cf22b426aa817fdc1d5766def867ab74L350-R440)
* Improved code style and consistency in test files and main action logic (e.g., arrow function formatting, trailing commas, and assertion formatting). [[1]](diffhunk://#diff-25842b7fdd198b8772289b4e61167ee3cf22b426aa817fdc1d5766def867ab74L84-R84) [[2]](diffhunk://#diff-25842b7fdd198b8772289b4e61167ee3cf22b426aa817fdc1d5766def867ab74L156-R156) [[3]](diffhunk://#diff-25842b7fdd198b8772289b4e61167ee3cf22b426aa817fdc1d5766def867ab74L272-R305) [[4]](diffhunk://#diff-25842b7fdd198b8772289b4e61167ee3cf22b426aa817fdc1d5766def867ab74L314-R342) [[5]](diffhunk://#diff-25842b7fdd198b8772289b4e61167ee3cf22b426aa817fdc1d5766def867ab74L325-R374) [[6]](diffhunk://#diff-25842b7fdd198b8772289b4e61167ee3cf22b426aa817fdc1d5766def867ab74L389-R464) [[7]](diffhunk://#diff-25842b7fdd198b8772289b4e61167ee3cf22b426aa817fdc1d5766def867ab74L419-R494) [[8]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L154-R202) [[9]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L187-R235) [[10]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L220-R268) [[11]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L229-R279)