### PR TITLE
feat!: upgrade to node24

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,8 @@ jobs:
       - run: npm test
   windows:
     runs-on: windows-latest
-    matrix:
+    strategy:
+      matrix:
         node: [20, 24]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [20]
+        node: [20, 24]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -26,18 +26,20 @@ jobs:
       - run: npm test
   windows:
     runs-on: windows-latest
+    matrix:
+        node: [20, 24]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ matrix.node }}
       - run: npm ci
       - run: npm test
   build-dist:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [20]
+        node: [20, 24]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/action.yml
+++ b/action.yml
@@ -75,5 +75,5 @@ inputs:
     required: false
     default: ''
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "automated releases based on conventional commits",
   "main": "index.js",
   "scripts": {
-    "test": "c8 mocha --node-option no-experimental-fetch --recursive --timeout=5000 build/test",
+    "test": "c8 mocha --recursive --timeout=5000 build/test",
     "prepare": "npm run compile",
     "lint": "gts check",
     "compile": "tsc -p .",


### PR DESCRIPTION
Node v20 is going to be EOL in April 2026 -- https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/, and is being deprecated by Github on March 4 2026. 

Addresses https://github.com/googleapis/release-please-action/issues/1162