### PR TITLE
fix: reuse single Manifest instance for releases and pull requests

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -105629,13 +105629,12 @@ async function main(fetchOverride) {
     core.info(`Running release-please version: ${release_please_1.VERSION}`);
     const inputs = parseInputs();
     const github = await getGitHubInstance(inputs, fetchOverride);
+    const manifest = await loadOrBuildManifest(github, inputs);
     if (!inputs.skipGitHubRelease) {
-        const manifest = await loadOrBuildManifest(github, inputs);
         core.debug('Creating releases');
         outputReleases(await manifest.createReleases());
     }
     if (!inputs.skipGitHubPullRequest) {
-        const manifest = await loadOrBuildManifest(github, inputs);
         core.debug('Creating pull requests');
         outputPRs(await manifest.createPullRequests());
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,15 +137,14 @@ export async function main(fetchOverride?: any) {
   core.info(`Running release-please version: ${VERSION}`)
   const inputs = parseInputs();
   const github = await getGitHubInstance(inputs, fetchOverride);
+  const manifest = await loadOrBuildManifest(github, inputs);
 
   if (!inputs.skipGitHubRelease) {
-    const manifest = await loadOrBuildManifest(github, inputs);
     core.debug('Creating releases');
     outputReleases(await manifest.createReleases());
   }
 
   if (!inputs.skipGitHubPullRequest) {
-    const manifest = await loadOrBuildManifest(github, inputs);
     core.debug('Creating pull requests');
     outputPRs(await manifest.createPullRequests());
   }


### PR DESCRIPTION
The main() function previously instantiated two separate Manifest objects: one for creating releases and another for creating pull requests. Each call to loadOrBuildManifest() triggered GitHub API requests to fetch repository configuration and release history.

When draft: true is enabled, this redundancy becomes especially costly because draft release resolution requires iterating through more GitHub API pages to find tagged releases, effectively doubling the API overhead.

This PR hoists the loadOrBuildManifest() call above both conditional blocks so a single, shared instance is used for both operations.

Fixes #1169