### PR TITLE
docs(README): bump action version from v4 to v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Automate releases with Conventional Commit Messages.
      release-please:
        runs-on: ubuntu-latest
        steps:
-         - uses: googleapis/release-please-action@v4
+         - uses: googleapis/release-please-action@v5
            with:
              # this assumes that you have created a personal access token
              # (PAT) and configured it as a GitHub action secret named
@@ -54,7 +54,7 @@ and then configure this action as follows:
 ```yaml
 #...(same as above)
 steps:
-  - uses: googleapis/release-please-action@v4
+  - uses: googleapis/release-please-action@v5
     with:
       # this assumes that you have created a personal access token
       # (PAT) and configured it as a GitHub action secret named
@@ -97,7 +97,7 @@ the `token` configuration option.
 If your repository is in an organization, you may need to
 [permit github actions to create an approve PRs](https://stackoverflow.com/questions/72376229).
 
-> [!WARNING]  
+> [!WARNING]
 > If using GitHub Actions, you will need to specify a `token` for your workflows to run on
 > Release Please's releases and PRs. See [the heading below](#other-actions-on-release-please-prs).
 
@@ -270,7 +270,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         with:
           release-type: node
           # The short ref name of the branch or tag that triggered
@@ -293,7 +293,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         id: release
         with:
           release-type: node
@@ -340,7 +340,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         id: release
         with:
           release-type: node
@@ -377,7 +377,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         id: release
         with:
           release-type: node


### PR DESCRIPTION
The README hasn't been updated to use the latest version of the action yet.