### PR TITLE
fix: handle non-Error rejections in main() catch block

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -227,6 +227,11 @@ function outputPRs(prs: (PullRequest | undefined)[]) {
 
 if (require.main === module) {
   main().catch(err => {
-    core.setFailed(`release-please failed: ${err.message}`)
+    if (err instanceof Error) {
+      core.setFailed(`release-please failed: ${err.message}`);
+      if (err.stack) core.debug(err.stack);
+    } else {
+      core.setFailed(`release-please failed: ${JSON.stringify(err)}`);
+    }
   })
 }


### PR DESCRIPTION
When `main()` rejects with something that is not an `Error` instance, or with an `Error` that has no `message`, the current catch handler produces:

```
release-please failed: undefined
```

or just:

```
release-please failed:
```

This PR fixes the catch block to guard on `err instanceof Error` before reading `.message`, falls back to `JSON.stringify(err)` for non-Error rejections, and logs the stack trace via `core.debug()` when available.